### PR TITLE
refactor(core): move utilities to composables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
         <strong>简体中文</strong>
     </a> • 
     <a href="#ongoing-polling">
-        <strong>Ongoing Polling</strong>
+        <strong>Polling</strong>
     </a> • 
     <a href="#common-questions">
         <strong>Q&A</strong>

--- a/assets/README.zh-Hans.md
+++ b/assets/README.zh-Hans.md
@@ -22,7 +22,7 @@
         <strong>English</strong>
     </a> • 
     <a href="#正在进行的投票">
-        <strong>正在进行的投票</strong>
+        <strong>投票</strong>
     </a> • 
     <a href="#常见问题">
         <strong>Q&A</strong>

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,9 @@
 import type { FileStat } from 'webdav';
+import { parseXML } from './composable/parse-xml';
 import { normalizeRemotePath, remoteBasename } from './platform/path';
 import { isNil } from './utils/fns';
 import { isRetryableError } from './utils/is-retryable-error';
 import logger from './utils/logger';
-import { parseXML } from './utils/parse-xml';
 import requestUrl from './utils/request-url';
 import sleep from './utils/sleep';
 

--- a/src/components/FilterEditorModal.ts
+++ b/src/components/FilterEditorModal.ts
@@ -1,7 +1,7 @@
 import { Modal, Setting } from 'obsidian';
 import WebDAVSyncPlugin from '~';
+import type { GlobMatchOptions } from '~/settings';
 import t from '~/i18n';
-import { getUserOptions, type GlobMatchOptions } from '~/utils/glob-match';
 
 enum FilterType {
 	Include = 'include',
@@ -68,10 +68,9 @@ export default class FilterEditorModal extends Modal {
 					cls: 'shadow-none!',
 				});
 				function updateButtonStatus() {
-					const opt = getUserOptions(filter);
 					const activeCls = ['bg-[var(--interactive-accent)]!'];
 					const inactiveCls = ['background-none!', 'hover:bg-[--interactive-normal]!'];
-					if (opt.caseSensitive) {
+					if (filter.options.caseSensitive) {
 						forceCaseBtn.classList.add(...activeCls);
 						forceCaseBtn.classList.remove(...inactiveCls);
 					} else {

--- a/src/components/SelectRemoteBaseDirModal.ts
+++ b/src/components/SelectRemoteBaseDirModal.ts
@@ -1,8 +1,8 @@
 import { App, Modal } from 'obsidian';
 import WebDAVSyncPlugin from '~';
 import { getDirectoryContents } from '~/api';
+import { mkdirsWebDAV } from '~/fs/webdav/utils';
 import { normalizeBaseDir, normalizePathToAbsolute, remoteBasename } from '~/platform/path';
-import { mkdirsWebDAV } from '~/utils/mkdirs-webdav';
 import { mount as mountWebDAVExplorer } from './explorer';
 
 export default class SelectRemoteBaseDirModal extends Modal {

--- a/src/composable/api-limiter.ts
+++ b/src/composable/api-limiter.ts
@@ -1,5 +1,3 @@
-import { useSettings, type PluginSettings } from '~/settings';
-
 /**
  * A simple rate limiter for API calls.
  * @param options.maxConcurrent - The maximum number of concurrent requests.
@@ -10,22 +8,12 @@ class ApiLimiter {
 	private lastStartTime = 0;
 	private readonly queue: Array<() => void> = [];
 	private timer: number | null = null;
-	private settings: PluginSettings | undefined;
+	maxConcurrency: number;
+	minInterval: number;
 
-	constructor() {
-		void (async () => (this.settings = await useSettings()))();
-	}
-
-	get maxConcurrent() {
-		if (!this.settings) return Infinity;
-		const field = this.settings.maxWebDAVConcurrency;
-		return field.enabled ? field.value : Infinity;
-	}
-
-	get minTime() {
-		if (!this.settings) return 0;
-		const field = this.settings.minWebDAVRequestInterval;
-		return field.enabled ? field.value : 0;
+	constructor({ maxConcurrency = Infinity, minInterval = 0 } = {}) {
+		this.maxConcurrency = maxConcurrency;
+		this.minInterval = minInterval;
 	}
 
 	schedule<T>(fn: () => T | Promise<T>): Promise<T> {
@@ -51,10 +39,10 @@ class ApiLimiter {
 	}
 
 	private processQueue() {
-		if (this.activeCount >= this.maxConcurrent || this.queue.length === 0) return;
+		if (this.activeCount >= this.maxConcurrency || this.queue.length === 0) return;
 
 		const now = Date.now();
-		const nextAllowed = this.lastStartTime + this.minTime;
+		const nextAllowed = this.lastStartTime + this.minInterval;
 		if (now < nextAllowed) {
 			if (this.timer) return;
 			this.timer = window.setTimeout(() => {
@@ -66,12 +54,9 @@ class ApiLimiter {
 
 		const task = this.queue.shift();
 		if (!task) return;
-
 		this.activeCount++;
 		this.lastStartTime = now;
-
 		task();
-
 		this.processQueue();
 	}
 }

--- a/src/composable/glob-match.ts
+++ b/src/composable/glob-match.ts
@@ -1,0 +1,93 @@
+import GlobToRegExp from 'glob-to-regexp';
+
+export interface UserOptions {
+	caseSensitive?: boolean;
+}
+
+function normalizePath(path: string): { normalized: string; segments: string[]; isDir: boolean } {
+	const withSlashes = path.replace(/\\/g, '/');
+	const isDir = withSlashes.endsWith('/');
+	const segments: string[] = [];
+	for (const seg of withSlashes.split('/')) {
+		if (!seg || seg === '.') continue;
+		if (seg === '..') segments.pop();
+		else segments.push(seg);
+	}
+	return { normalized: segments.join('/'), segments, isDir };
+}
+
+function buildRegExp(expr: string, opts: UserOptions): RegExp | undefined {
+	return GlobToRegExp(expr, {
+		flags: opts.caseSensitive ? '' : 'i',
+		extended: true,
+		globstar: true,
+	});
+}
+
+export default class GlobMatch {
+	private regex?: RegExp;
+	private anchored: boolean;
+	private dirOnly: boolean;
+	private hasSlash: boolean;
+	private hasWildcards: boolean;
+	private body: string;
+
+	constructor(
+		public expr: string,
+		public options: UserOptions = {},
+	) {
+		const trimmed = expr.trim();
+		this.anchored = trimmed.startsWith('/');
+		this.dirOnly = trimmed.endsWith('/');
+		this.body = trimmed.replace(/^\/+|\/+$/g, '');
+		this.hasSlash = this.body.includes('/');
+		this.hasWildcards = /[*?[]/.test(this.body);
+		if (this.body) this.regex = buildRegExp(this.body, options);
+	}
+
+	private matchesNormalizedPath(normalized: string, segments: string[], isDir: boolean): boolean {
+		if (!this.regex) return false;
+		const matchesAnySegment = (): boolean =>
+			segments.some((segment) => this.regex?.test(segment) ?? false);
+
+		if (!this.hasSlash) {
+			if (this.anchored) {
+				if (segments.length === 0 || !this.regex.test(segments[0])) return false;
+				if (this.dirOnly) return segments.length > 1 || isDir;
+				return true;
+			}
+
+			if (this.dirOnly) {
+				return segments.some(
+					(segment, index) =>
+						segment === this.body && (index < segments.length - 1 || isDir),
+				);
+			}
+
+			return matchesAnySegment();
+		}
+
+		if (this.hasWildcards) return this.regex.test(normalized);
+		if (this.dirOnly) return normalized === this.body && isDir;
+		return normalized === this.body;
+	}
+
+	matchesPath(path: string): boolean {
+		const { normalized, segments, isDir } = normalizePath(path);
+		return this.matchesNormalizedPath(normalized, segments, isDir);
+	}
+
+	matchesAncestor(path: string): boolean {
+		const { segments } = normalizePath(path);
+		for (let index = 0; index < segments.length - 1; index++) {
+			const prefixSegments = segments.slice(0, index + 1);
+			if (this.matchesNormalizedPath(prefixSegments.join('/'), prefixSegments, true))
+				return true;
+		}
+		return false;
+	}
+
+	test(path: string): boolean {
+		return this.matchesPath(path) || this.matchesAncestor(path);
+	}
+}

--- a/src/composable/i18n.ts
+++ b/src/composable/i18n.ts
@@ -1,0 +1,52 @@
+type Primitive = string | number | boolean | null | undefined;
+type InterpolationValues = Record<string, Primitive>;
+
+type KeyOfObject<T, P extends string = ''> = T extends object
+	? {
+			[K in keyof T]: K extends string
+				? T[K] extends object
+					? KeyOfObject<T[K], `${P}${K}.`>
+					: `${P}${K}`
+				: never;
+		}[keyof T]
+	: never;
+
+type StringTree = { [key: string]: string | StringTree };
+type Resources<TranslationShape extends StringTree> = Record<string, TranslationShape>;
+type CreateI18nOptions<TranslationShape extends {}, T extends Resources<TranslationShape>> = {
+	resources: T;
+	current: keyof T;
+};
+
+export default function createI18n<TranslationShape extends StringTree>(
+	options: CreateI18nOptions<TranslationShape, Resources<TranslationShape>>,
+) {
+	type Languages = keyof Resources<TranslationShape>;
+	type TranslationKey = KeyOfObject<TranslationShape>;
+	function getValue(resource: TranslationShape, key: string) {
+		const value = key
+			.split('.')
+			.reduce<StringTree | string>(
+				(current, segment) => (current as StringTree)[segment],
+				resource,
+			);
+		return value as string;
+	}
+	return {
+		translation: (key: TranslationKey, params?: InterpolationValues): string => {
+			const template = getValue(options.resources[options.current], key);
+			return interpolate(template, params);
+		},
+		changeLanguage: (language: Languages) => {
+			options.current = language;
+		},
+	};
+}
+
+function interpolate(template: string, params?: InterpolationValues): string {
+	if (params === undefined) return template;
+	return template.replace(/\{\{\s*([^{}\s]+)\s*\}\}/g, (match, key: string) => {
+		const value = params[key];
+		return value === undefined ? match : String(value);
+	});
+}

--- a/src/composable/parse-xml.ts
+++ b/src/composable/parse-xml.ts
@@ -14,8 +14,6 @@ export function parseXML(xml: string): never {
 		let textContent = '';
 		const elementChildren: Element[] = [];
 
-		// attributeNamePrefix: '' & removeNSPrefix: true
-		// Using `localName` automatically strips namespace prefixes
 		for (let i = 0; i < elem.attributes.length; i++) {
 			const attr = elem.attributes[i];
 			result[attr.localName] = attr.value;
@@ -23,11 +21,9 @@ export function parseXML(xml: string): never {
 
 		// Collect text and child elements
 		for (const child of elem.childNodes) {
-			if (child.nodeType === Node.TEXT_NODE || child.nodeType === Node.CDATA_SECTION_NODE) {
+			if (child.nodeType === Node.TEXT_NODE || child.nodeType === Node.CDATA_SECTION_NODE)
 				textContent += child.nodeValue || '';
-			} else if (child.nodeType === Node.ELEMENT_NODE) {
-				elementChildren.push(child as Element);
-			}
+			else if (child.nodeType === Node.ELEMENT_NODE) elementChildren.push(child as Element);
 		}
 		textContent = textContent.trim();
 
@@ -41,22 +37,10 @@ export function parseXML(xml: string): never {
 
 		const hasAttributes = elem.attributes.length > 0;
 		const hasChildren = Object.keys(grouped).length > 0;
-
-		// parseTagValue: false -> keep everything as strings
-		// If only text and no attributes/children, return plain string
-		if (!hasAttributes && !hasChildren && textContent) {
-			return textContent;
-		}
-
-		// If mixed content or attributes exist, store text under `#text`
-		if (textContent) {
-			result['#text'] = textContent;
-		}
-
-		// Flatten single-child arrays to match fast-xml-parser behavior
-		for (const [name, children] of Object.entries(grouped)) {
+		if (!hasAttributes && !hasChildren && textContent) return textContent;
+		if (textContent) result['#text'] = textContent;
+		for (const [name, children] of Object.entries(grouped))
 			result[name] = children.length === 1 ? children[0] : children;
-		}
 
 		return result;
 	};

--- a/src/composable/unit-converter.ts
+++ b/src/composable/unit-converter.ts
@@ -1,0 +1,33 @@
+type UnitMap = Record<string, number>;
+type UnitConfig<T extends UnitMap> = {
+	units: T;
+	defaultUnit: keyof T;
+};
+
+function round(value: number, precision: number): number {
+	return Math.round(value * precision) / precision;
+}
+
+export default function createUnitConverter<T extends UnitMap>({
+	units,
+	defaultUnit,
+}: UnitConfig<T>) {
+	const entries = Object.entries(units);
+	const unitMap: Record<string, number> = {};
+	entries.forEach(([u, multiplier]) => (unitMap[u.toLowerCase()] = multiplier));
+	return {
+		parse: (input: string): number | undefined => {
+			const match = input.trim().match(/^(-?\d+(?:\.\d+)?)\s*([a-z]*)$/i);
+			if (!match) return undefined;
+			const num = parseFloat(match[1]);
+			if (!Number.isFinite(num) || num < 0) return undefined;
+			const rawUnit = (match[2] || (defaultUnit as string)).toLowerCase();
+			return rawUnit in unitMap ? num * unitMap[rawUnit] : undefined;
+		},
+		format: (value: number): string => {
+			const entry = entries[entries.findLastIndex(([, v]) => value >= v)] || entries[0];
+			const scaled = value / entry[1];
+			return `${round(scaled, 2)} ${entry[0]}`;
+		},
+	};
+}

--- a/src/fs/post-traversal.ts
+++ b/src/fs/post-traversal.ts
@@ -1,6 +1,7 @@
+import type { GlobMatchOptions } from '~/settings';
 import type { StatsMap } from '~/types';
 import { vaultDirname } from '~/platform/path';
-import { buildRules, needIncludeFromGlobRules, type GlobMatchOptions } from '~/utils/glob-match';
+import { buildRules, needIncludeFromGlobRules } from '~/utils/glob-match';
 import logger from '~/utils/logger';
 
 // Apply inclusion / exclusion / file size rules and filter out invalid entries

--- a/src/fs/webdav/traverse.ts
+++ b/src/fs/webdav/traverse.ts
@@ -1,8 +1,8 @@
 import type { StatsMap } from '~/types';
 import { getDirectoryContents } from '~/api';
+import { apiLimiter } from '~/composable/api-limiter';
 import { normalizePathToAbsolute, normalizePathToRelative } from '~/platform/path';
 import { useSettings } from '~/settings';
-import { apiLimiter } from '~/utils/api-limiter';
 import { isRetryableError } from '~/utils/is-retryable-error';
 import logger from '~/utils/logger';
 import sleep from '~/utils/sleep';

--- a/src/fs/webdav/utils.ts
+++ b/src/fs/webdav/utils.ts
@@ -18,3 +18,9 @@ export async function getContent(webdav: WebDAVClient, path: string) {
 	const content = (await webdav.getFileContents(path)) as BinaryLike;
 	return toArrayBuffer(content);
 }
+
+export function mkdirsWebDAV(client: WebDAVClient, path: string) {
+	return client.createDirectory(path, {
+		recursive: true,
+	});
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,50 +1,28 @@
-import type { InterpolationValues, KeyOfObject } from '~/types';
+import createI18n from '~/composable/i18n';
 import en from './enold';
 import ru from './ru';
 import zhHans from './zh-Hans';
 
-type Language = keyof typeof resources;
-export type TranslationResource = typeof en;
-type TranslationKey = KeyOfObject<TranslationResource>;
-
-const fallbackLanguage: Language = 'en';
 const resources = {
 	'zh-Hans': zhHans,
 	en,
 	ru,
-} as const satisfies Record<string, TranslationResource>;
-let currentLanguage = resolveLanguage();
+} as const;
+type Languages = keyof typeof resources;
+export type TranslationShape = typeof en;
 
-function getValue(resource: TranslationResource, key: string): string | undefined {
-	const value = key.split('.').reduce<unknown>((current, segment) => {
-		if (current === null || typeof current !== 'object') return undefined;
-		return (current as Record<string, unknown>)[segment];
-	}, resource);
+export default createI18n<TranslationShape>({
+	current: resolveLanguage(),
+	resources,
+}).translation;
 
-	return typeof value === 'string' ? value : undefined;
-}
-
-function interpolate(template: string, params?: InterpolationValues): string {
-	if (params === undefined) return template;
-	return template.replace(/\{\{\s*([^{}\s]+)\s*\}\}/g, (match, key: string) => {
-		const value = params[key];
-		return value === undefined ? match : String(value);
-	});
-}
-
-function isLanguage(key: string): key is Language {
+function isLanguage(key: string): key is Languages {
 	return key in resources;
 }
 
-function resolveLanguage(): Language {
+function resolveLanguage(): Languages {
 	const code = window.localStorage.getItem('language') ?? navigator.language;
 	const segments = code.split('-');
 	if (segments[0] === 'zh') return 'zh-Hans';
-	return isLanguage(segments[0]) ? segments[0] : fallbackLanguage;
-}
-
-export default function t(key: TranslationKey, params?: InterpolationValues): string {
-	const template =
-		getValue(resources[currentLanguage], key) ?? getValue(resources.en, key) ?? key;
-	return interpolate(template, params);
+	return isLanguage(segments[0]) ? segments[0] : 'en';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import './webdav-patch';
 import './assets/global.css';
 import { Plugin } from 'obsidian';
-import type { GlobMatchOptions } from './utils/glob-match';
 import { SyncRibbonManager } from './components/SyncRibbonManager';
 import { syncCancel } from './events';
 import { normalizeBaseDir } from './platform/path';
@@ -18,6 +17,7 @@ import {
 	setPluginInstance,
 	ConflictStrategy,
 	UnmergeableStrategy,
+	type GlobMatchOptions,
 } from './settings';
 import { processSettings } from './settings/process';
 import {

--- a/src/platform/path.ts
+++ b/src/platform/path.ts
@@ -1,5 +1,5 @@
 function splitSegments(path: string): string[] {
-	const normalized = path.replaceAll('\\', '/');
+	const normalized = path.replace(/\\/g, '/');
 	const segments = normalized.split('/');
 	const resolved: string[] = [];
 

--- a/src/services/webdav.service.ts
+++ b/src/services/webdav.service.ts
@@ -1,6 +1,6 @@
 import { createClient, type WebDAVClient } from 'webdav';
 import WebDAVSyncPlugin from '~';
-import { apiLimiter } from '~/utils/api-limiter';
+import { apiLimiter } from '~/composable/api-limiter';
 import { getCredential } from '~/utils/get-credential';
 
 export function createRateLimitedWebDAVClient(client: WebDAVClient): WebDAVClient {

--- a/src/settings/controls.ts
+++ b/src/settings/controls.ts
@@ -1,4 +1,5 @@
 import { Setting } from 'obsidian';
+import { apiLimiter } from '~/composable/api-limiter';
 import t from '~/i18n';
 import generateSettingEntry, { UserInputType } from './generate-setting-entry';
 import BaseSettings from './settings.base';
@@ -28,6 +29,7 @@ export default class ControlsSettings extends BaseSettings {
 			type: UserInputType.Number,
 			saveSettings: this.plugin.saveSettings,
 			rejectZero: true,
+			onChange: (value) => (apiLimiter.maxConcurrency = value),
 		});
 
 		generateSettingEntry({
@@ -49,6 +51,7 @@ export default class ControlsSettings extends BaseSettings {
 			field: this.plugin.settings.minWebDAVRequestInterval,
 			type: UserInputType.Time,
 			saveSettings: this.plugin.saveSettings,
+			onChange: (value) => (apiLimiter.minInterval = value),
 		});
 
 		generateSettingEntry({

--- a/src/settings/generate-setting-entry.ts
+++ b/src/settings/generate-setting-entry.ts
@@ -1,4 +1,4 @@
-import { Notice, Setting, TextComponent } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 import type { ToggleNumericSettingsField } from '~/types';
 import t from '~/i18n';
 import { formatFileSize, formatTime, parseFileSize, parseTime } from '~/utils/input-converters';
@@ -20,6 +20,7 @@ export default function generateSettingEntry({
 	type,
 	saveSettings,
 	rejectZero,
+	onChange,
 }: {
 	container: HTMLElement;
 	name: string;
@@ -29,14 +30,13 @@ export default function generateSettingEntry({
 	type: UserInputType;
 	saveSettings: () => Promise<void>;
 	rejectZero?: boolean;
+	onChange?: (value: number) => void;
 }) {
-	let textComponent: TextComponent;
 	new Setting(container)
 		.setClass('numeric-toggle')
 		.setName(name)
 		.setDesc(desc)
 		.addText((text) => {
-			textComponent = text;
 			text.setPlaceholder(placeholder).setValue(format(field.value, type));
 			text.inputEl.addEventListener('blur', () => {
 				const value = parse(text.inputEl.value, type);
@@ -53,11 +53,11 @@ export default function generateSettingEntry({
 				}
 				if (value !== field.value) {
 					field.value = value;
+					onChange?.(value);
 					void saveSettings();
 				}
 				text.inputEl.value = format(field.value, type);
 			});
-			text.setDisabled(!field.enabled);
 		})
 		.addToggle((toggle) => {
 			toggle.setValue(field.enabled);
@@ -65,7 +65,6 @@ export default function generateSettingEntry({
 				if (value !== field.enabled) {
 					field.enabled = value;
 					void saveSettings();
-					textComponent.setDisabled(!field.enabled);
 				}
 			});
 		});

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,7 +1,7 @@
 import type WebDAVSyncPlugin from '~';
 import { App, PluginSettingTab } from 'obsidian';
+import type { UserOptions } from '~/composable/glob-match';
 import type { ToggleNumericSettingsField } from '~/types';
-import type { GlobMatchOptions } from '~/utils/glob-match';
 import waitUntil from '~/utils/wait-until';
 import AccountSettings from './account';
 import CommonSettings from './common';
@@ -22,6 +22,11 @@ export enum UnmergeableStrategy {
 	KeepLocal = 'keepLocal',
 	KeepRemote = 'keepRemote',
 	Skip = 'skip',
+}
+
+export interface GlobMatchOptions {
+	expr: string;
+	options: UserOptions;
 }
 
 export interface PluginSettings {

--- a/src/storage/file-chunk.store.ts
+++ b/src/storage/file-chunk.store.ts
@@ -1,4 +1,4 @@
-import localspace from 'localspace';
+import localspace, { ttlPlugin } from 'localspace';
 import { isSub } from '~/utils/is-sub';
 import logger from '~/utils/logger';
 import {
@@ -20,6 +20,7 @@ export class IndexedDbFileChunkStore {
 		storeName: FILE_CHUNK_STORE_NAME,
 		driver: [localspace.INDEXEDDB],
 		coalesceWrites: false,
+		plugins: [ttlPlugin({ defaultTTL: 60 * 1000 * 60 * 10 })],
 	});
 
 	async initialize() {

--- a/src/sync/tasks/task.interface.ts
+++ b/src/sync/tasks/task.interface.ts
@@ -1,6 +1,6 @@
 import type { WebDAVClient } from 'webdav';
 import { Vault } from 'obsidian';
-import type { TranslationResource } from '~/i18n';
+import type { TranslationShape } from '~/i18n';
 import type { SyncRecord } from '~/storage';
 import type { MaybePromise } from '~/types';
 import getTaskName from '~/utils/get-task-name';
@@ -33,7 +33,7 @@ export abstract class BaseTask<T extends TaskOptions = TaskOptions> {
 		this.local = options.local;
 		this.remote = options.remote;
 	}
-	readonly name?: keyof TranslationResource['sync']['fileOp'];
+	readonly name?: keyof TranslationShape['sync']['fileOp'];
 	readonly localPath: string;
 	readonly remotePath: string;
 	protected readonly webdav: WebDAVClient;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,19 +27,6 @@ export type RecordStatsMap = Map<string, RecordStatModel>;
 
 export type MaybePromise<T> = Promise<T> | T;
 
-type Primitive = string | number | boolean | null | undefined;
-export type InterpolationValues = Record<string, Primitive>;
-
-export type KeyOfObject<T, P extends string = ''> = T extends object
-	? {
-			[K in keyof T]: K extends string
-				? T[K] extends object
-					? KeyOfObject<T[K], `${P}${K}.`>
-					: `${P}${K}`
-				: never;
-		}[keyof T]
-	: never;
-
 export type ToggleNumericSettingsField = {
 	enabled: boolean;
 	value: number;

--- a/src/utils/fns.ts
+++ b/src/utils/fns.ts
@@ -1,5 +1,3 @@
-import { hash } from '~/platform/crypto';
-
 export function isNil(value: unknown): value is null | undefined {
 	return value === null || value === undefined;
 }
@@ -8,10 +6,6 @@ export function chunk<T>(arr: T[], size: number): T[][] {
 	const chunks: T[][] = [];
 	for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size));
 	return chunks;
-}
-
-export function isEqual(a: unknown, b: unknown): boolean {
-	return hash(a) === hash(b);
 }
 
 export function zipMerge<T>(arr1: T[][], arr2: T[][]): T[][] {
@@ -25,8 +19,4 @@ export function zipMerge<T>(arr1: T[][], arr2: T[][]): T[][] {
 	}
 
 	return result;
-}
-
-export function round(value: number, precision: number): number {
-	return Math.round(value * precision) / precision;
 }

--- a/src/utils/glob-match.ts
+++ b/src/utils/glob-match.ts
@@ -1,147 +1,24 @@
-import GlobToRegExp from 'glob-to-regexp';
+import GlobMatch, { type UserOptions } from '~/composable/glob-match';
 
-export interface GlobMatchUserOptions {
-	caseSensitive: boolean;
-}
-
-export interface GlobMatchOptions {
-	expr: string;
-	options: GlobMatchUserOptions;
-}
-
-const DEFAULT_USER_OPTIONS: GlobMatchUserOptions = {
-	caseSensitive: false,
-};
-
-export function isVoidGlobMatchOptions(options: GlobMatchOptions): boolean {
-	return options.expr.trim() === '';
-}
-
-function generateFlags(options: GlobMatchUserOptions) {
-	let flags = '';
-	if (!options.caseSensitive) flags += 'i';
-	return flags;
-}
-
-function normalizePath(rawPath: string) {
-	const isDirPath = rawPath.replaceAll('\\', '/').endsWith('/');
-	const normalized = rawPath
-		.replaceAll('\\', '/')
-		.split('/')
-		.filter((segment, index) => segment !== '' || index === 0)
-		.reduce<string[]>((segments, segment) => {
-			if (segment === '' || segment === '.') return segments;
-			if (segment === '..') {
-				segments.pop();
-				return segments;
-			}
-			segments.push(segment);
-			return segments;
-		}, [])
-		.join('/');
-	const trimmed = normalized.replace(/^\.+\//, '').replace(/^\/+/, '');
-	const segments = trimmed ? trimmed.split('/').filter(Boolean) : [];
-	return {
-		normalized: segments.join('/'),
-		segments,
-		isDirPath,
-	};
-}
-
-function buildRegExp(expr: string, options: GlobMatchUserOptions) {
-	return GlobToRegExp(expr, {
-		flags: generateFlags(options),
-		extended: true,
-		globstar: true,
-	});
-}
-
-export default class GlobMatch {
-	private re: RegExp;
-	private readonly isRooted: boolean;
-	private readonly isDirOnly: boolean;
-	private readonly hasSlash: boolean;
-	private readonly patternBody: string;
-	private readonly pathRegex?: RegExp;
-	private readonly segmentRegex?: RegExp;
-
-	constructor(
-		public expr: string,
-		public options: GlobMatchUserOptions,
-	) {
-		const trimmed = expr.trim();
-		this.isRooted = trimmed.startsWith('/');
-		this.isDirOnly = trimmed.endsWith('/');
-		this.patternBody = trimmed.slice(this.isRooted ? 1 : 0, this.isDirOnly ? -1 : undefined);
-		this.hasSlash = this.patternBody.includes('/');
-		if (this.patternBody !== '') {
-			if (this.isRooted || this.hasSlash) {
-				this.pathRegex = buildRegExp(this.patternBody, options);
-				this.re = this.pathRegex;
-			} else {
-				this.segmentRegex = buildRegExp(this.patternBody, options);
-				this.re = this.segmentRegex;
-			}
-		} else {
-			this.re = /^$/;
-		}
-	}
-
-	private matchDirectoryBySegments(segments: string[], isDirPath: boolean) {
-		for (let i = 0; i < segments.length; i += 1) {
-			const isSegmentDir = i < segments.length - 1 || isDirPath;
-			if (!isSegmentDir) continue;
-			if (this.segmentRegex?.test(segments[i])) return true;
-		}
-		return false;
-	}
-
-	private matchDirectoryByPrefix(segments: string[], isDirPath: boolean) {
-		for (let i = 1; i <= segments.length; i += 1) {
-			const isSegmentDir = i < segments.length || isDirPath;
-			if (!isSegmentDir) continue;
-			const prefix = segments.slice(0, i).join('/');
-			if (this.pathRegex?.test(prefix)) return true;
-		}
-		return false;
-	}
-
-	test(path: string) {
-		if (this.patternBody === '') return false;
-		const { normalized, segments, isDirPath } = normalizePath(path);
-		if (this.isDirOnly) {
-			if (this.isRooted || this.hasSlash)
-				return this.matchDirectoryByPrefix(segments, isDirPath);
-			return this.matchDirectoryBySegments(segments, isDirPath);
-		}
-		if (this.isRooted || this.hasSlash) return this.pathRegex?.test(normalized) ?? false;
-		return segments.some((segment) => this.segmentRegex?.test(segment));
-	}
-}
-
-export function getUserOptions(opt: GlobMatchOptions | string): GlobMatchUserOptions {
-	if (typeof opt === 'string') return structuredClone(DEFAULT_USER_OPTIONS);
-	return opt.options ?? structuredClone(DEFAULT_USER_OPTIONS);
+export function buildRules(
+	rules: Array<{ expr: string; options?: UserOptions }> = [],
+): GlobMatch[] {
+	return rules
+		.filter((rule) => rule.expr?.trim())
+		.map((rule) => new GlobMatch(rule.expr, rule.options));
 }
 
 export function needIncludeFromGlobRules(
 	path: string,
 	inclusion: GlobMatch[],
 	exclusion: GlobMatch[],
-) {
-	for (const rule of inclusion) if (rule.test(path)) return true;
-	for (const rule of exclusion) if (rule.test(path)) return false;
-	const { segments } = normalizePath(path);
-	const parentCount = Math.max(segments.length - 1, 0);
-	for (let i = 1; i <= parentCount; i += 1) {
-		const parentPath = `${segments.slice(0, i).join('/')}/`;
-		for (const rule of exclusion) if (rule.test(parentPath)) return false;
-	}
-	return true;
-}
+): boolean {
+	for (const rule of exclusion) if (rule.matchesAncestor(path)) return false;
 
-export function buildRules(rules: GlobMatchOptions[] = []): GlobMatch[] {
-	return rules
-		.filter((opt) => !isVoidGlobMatchOptions(opt))
-		.map(({ expr, options }) => new GlobMatch(expr, options));
+	const included = inclusion.some((rule) => rule.matchesPath(path));
+	if (inclusion.length > 0 && !included) return false;
+	if (included) return true;
+
+	for (const rule of exclusion) if (rule.matchesPath(path)) return false;
+	return true;
 }

--- a/src/utils/input-converters.ts
+++ b/src/utils/input-converters.ts
@@ -1,45 +1,15 @@
-import { round } from './fns';
-
-interface UnitConfig<T extends string = string> {
-	units: readonly T[];
-	multipliers: readonly number[];
-	defaultUnit: T;
-}
-
-function createUnitConverter<T extends string>(config: UnitConfig<T>) {
-	const { units, multipliers, defaultUnit } = config;
-	const unitMap = new Map<string, number>();
-	units.forEach((u, i) => unitMap.set(u.toLowerCase(), multipliers[i]));
-	return {
-		parse: (input: string): number | undefined => {
-			const match = input.trim().match(/^(-?\d+(?:\.\d+)?)\s*([a-z]*)$/i);
-			if (!match) return undefined;
-			const num = parseFloat(match[1]);
-			if (!Number.isFinite(num) || num < 0) return undefined;
-			const rawUnit = match[2].toLowerCase() || defaultUnit.toLowerCase();
-			if (!unitMap.has(rawUnit)) return undefined;
-			return num * (unitMap.get(rawUnit) as number);
-		},
-		format: (value: number): string => {
-			let idx = units.length - 1;
-			while (idx > 0 && value < multipliers[idx]) idx--;
-			const scaled = value / multipliers[idx];
-			return `${round(scaled, 2)} ${units[idx]}`;
-		},
-	};
-}
+import createUnitConverter from '~/composable/unit-converter';
 
 const fileSizeConverter = createUnitConverter({
-	units: ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const,
-	multipliers: [1, 2 ** 10, 2 ** 20, 2 ** 30, 2 ** 40, 2 ** 50],
+	// this is academically inaccurate since the following units are actually KiB, MiB, GiB, etc.
+	units: { B: 1, KB: 2 ** 10, MB: 2 ** 20, GB: 2 ** 30, TB: 2 ** 40 },
 	defaultUnit: 'MB',
 });
 export const parseFileSize = fileSizeConverter.parse;
 export const formatFileSize = fileSizeConverter.format;
 
 const timeConverter = createUnitConverter({
-	units: ['ms', 's', 'min', 'h', 'd'] as const,
-	multipliers: [1, 1e3, 6e4, 3.6e6, 8.64e7],
+	units: { ms: 1, s: 1e3, min: 6e4, h: 3.6e6, d: 8.64e7 },
 	defaultUnit: 's',
 });
 export const parseTime = timeConverter.parse;

--- a/src/utils/mkdirs-webdav.ts
+++ b/src/utils/mkdirs-webdav.ts
@@ -1,7 +1,0 @@
-import type { WebDAVClient } from 'webdav';
-
-export function mkdirsWebDAV(client: WebDAVClient, path: string) {
-	return client.createDirectory(path, {
-		recursive: true,
-	});
-}

--- a/src/utils/wait-until.ts
+++ b/src/utils/wait-until.ts
@@ -3,9 +3,7 @@ import sleep from './sleep';
 export default async function waitUntil<T>(condition: () => T, duration = 100) {
 	while (true) {
 		const result = await Promise.resolve(condition());
-		if (result) {
-			return result;
-		}
+		if (result) return result;
 		await sleep(duration);
 	}
 }

--- a/tests/glob-match.test.ts
+++ b/tests/glob-match.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import GlobMatch, { needIncludeFromGlobRules } from '~/utils/glob-match';
+import GlobMatch from '~/composable/glob-match';
+import { needIncludeFromGlobRules } from '~/utils/glob-match';
 
 const options = { caseSensitive: false };
 
@@ -7,7 +8,7 @@ const makeRules = (patterns: string[]) =>
 	patterns.map((pattern) => new GlobMatch(pattern, options));
 
 describe('needIncludeFromGlobRules', () => {
-	it('默认情况：无规则时应包含所有文件', () => {
+	it('includes every file when no rules are defined', () => {
 		expect(needIncludeFromGlobRules('some/file.txt', [], [])).toBe(true);
 		expect(needIncludeFromGlobRules('some/../file.txt', [], [])).toBe(true);
 		expect(needIncludeFromGlobRules('./some/file.txt', [], [])).toBe(true);
@@ -18,29 +19,29 @@ describe('needIncludeFromGlobRules', () => {
 		expect(needIncludeFromGlobRules('some/././file.txt', [], [])).toBe(true);
 	});
 
-	it('包含规则：匹配包含规则的文件应被包含', () => {
+	it('includes files matched by include rules', () => {
 		const inclusion = makeRules(['*.txt']);
 		const exclusion: GlobMatch[] = [];
 
 		expect(needIncludeFromGlobRules('document.txt', inclusion, exclusion)).toBe(true);
 	});
 
-	it('排除规则：匹配排除规则的文件应被排除', () => {
+	it('excludes files matched by exclude rules', () => {
 		const inclusion: GlobMatch[] = [];
 		const exclusion = makeRules(['*.log']);
 
 		expect(needIncludeFromGlobRules('debug.log', inclusion, exclusion)).toBe(false);
 	});
 
-	it('优先级：包含规则优先于排除规则', () => {
+	it('prefers include rules over exclude rules', () => {
 		const inclusion = makeRules(['important.log']);
 		const exclusion = makeRules(['*.log']);
 
 		expect(needIncludeFromGlobRules('important.log', inclusion, exclusion)).toBe(true);
 	});
 
-	describe('标准通配符', () => {
-		it('* 匹配零个或多个字符，但不跨目录', () => {
+	describe('Standard wildcards', () => {
+		it('* matches zero or more characters within a path segment', () => {
 			const exclusion = makeRules(['*.txt']);
 
 			expect(needIncludeFromGlobRules('readme.txt', [], exclusion)).toBe(false);
@@ -53,7 +54,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('dir.with.dot/readme.txt', [], exclusion)).toBe(false);
 		});
 
-		it('? 匹配任意单个字符', () => {
+		it('? matches any single character', () => {
 			const exclusion = makeRules(['debug?.log']);
 
 			expect(needIncludeFromGlobRules('debug1.log', [], exclusion)).toBe(false);
@@ -64,7 +65,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('debugä.log', [], exclusion)).toBe(false);
 		});
 
-		it('[] 匹配指定字符或范围', () => {
+		it('[] matches a character set or range', () => {
 			const exclusion = makeRules(['backup[0-9].sql']);
 
 			expect(needIncludeFromGlobRules('backup0.sql', [], exclusion)).toBe(false);
@@ -76,8 +77,8 @@ describe('needIncludeFromGlobRules', () => {
 		});
 	});
 
-	describe('路径分隔符规则', () => {
-		it('模式中不包含 /：递归匹配所有目录', () => {
+	describe('Path separator rules', () => {
+		it('patterns without / match recursively in any directory', () => {
 			const exclusion = makeRules(['*.log', 'temp']);
 
 			expect(needIncludeFromGlobRules('app.log', [], exclusion)).toBe(false);
@@ -94,7 +95,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('temporary/file.txt', [], exclusion)).toBe(true);
 		});
 
-		it('模式以 / 开头：仅匹配根目录', () => {
+		it('patterns starting with / match only the root directory', () => {
 			const exclusion = makeRules(['/TODO']);
 
 			expect(needIncludeFromGlobRules('TODO', [], exclusion)).toBe(false);
@@ -106,7 +107,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('nested/TODO', [], exclusion)).toBe(true);
 		});
 
-		it('模式以 / 结尾：仅匹配目录及其内容', () => {
+		it('patterns ending with / match directories and their contents', () => {
 			const exclusion = makeRules(['build/']);
 
 			expect(needIncludeFromGlobRules('build/', [], exclusion)).toBe(false);
@@ -120,7 +121,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('build/.hidden', [], exclusion)).toBe(false);
 		});
 
-		it('父目录被忽略时子文件应直接被忽略', () => {
+		it('ignored parent directories stay ignored', () => {
 			const exclusion = makeRules(['build/']);
 
 			expect(needIncludeFromGlobRules('build/', [], exclusion)).toBe(false);
@@ -129,11 +130,11 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('build/sub/', [], exclusion)).toBe(false);
 		});
 
-		it('父目录忽略可以被子文件白名单覆盖', () => {
+		it('a child include does not unignore an ignored parent directory', () => {
 			const inclusion = makeRules(['build/keep.txt']);
 			const exclusion = makeRules(['build/']);
 
-			expect(needIncludeFromGlobRules('build/keep.txt', inclusion, exclusion)).toBe(true);
+			expect(needIncludeFromGlobRules('build/keep.txt', inclusion, exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('build/keep/more.txt', inclusion, exclusion)).toBe(
 				false,
 			);
@@ -142,19 +143,19 @@ describe('needIncludeFromGlobRules', () => {
 			);
 		});
 
-		it('包含普通路径默认不递归，子路径仍可被排除', () => {
+		it('a plain include path does not recurse into children', () => {
 			const inclusion = makeRules(['aaa/bb']);
 			const exclusion = makeRules(['aaa/bb/cc']);
 
 			expect(needIncludeFromGlobRules('aaa/bb', inclusion, exclusion)).toBe(true);
-			expect(needIncludeFromGlobRules('aaa/bb/file.md', inclusion, exclusion)).toBe(true);
+			expect(needIncludeFromGlobRules('aaa/bb/file.md', inclusion, exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('aaa/bb/cc', inclusion, exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('aaa/bb/cc/child.md', inclusion, exclusion)).toBe(
 				false,
 			);
 		});
 
-		it('包含路径使用 /** 时递归包含，并继续优先于排除规则', () => {
+		it('a include path with /** recurses and still wins over exclude rules', () => {
 			const inclusion = makeRules(['aaa/bb/**']);
 			const exclusion = makeRules(['aaa/bb/cc/**']);
 
@@ -165,7 +166,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('aaa/bb/cc/file.md', inclusion, exclusion)).toBe(true);
 		});
 
-		it('模式中间包含 /：相对路径匹配', () => {
+		it('patterns containing / match relative paths', () => {
 			const exclusion = makeRules(['doc/*.txt']);
 
 			expect(needIncludeFromGlobRules('doc/a.txt', [], exclusion)).toBe(false);
@@ -176,8 +177,8 @@ describe('needIncludeFromGlobRules', () => {
 		});
 	});
 
-	describe('双星号 ** 深度匹配', () => {
-		it('**/pattern：任意深度匹配文件名', () => {
+	describe('Double-star ** matching', () => {
+		it('**/pattern matches file names at any depth', () => {
 			const exclusion = makeRules(['**/__pycache__']);
 
 			expect(needIncludeFromGlobRules('__pycache__', [], exclusion)).toBe(false);
@@ -188,7 +189,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('src/__pycache__/file.py', [], exclusion)).toBe(false);
 		});
 
-		it('pattern/**：匹配该目录下所有内容', () => {
+		it('pattern/** matches everything under that directory', () => {
 			const exclusion = makeRules(['assets/**']);
 
 			expect(needIncludeFromGlobRules('assets/logo.png', [], exclusion)).toBe(false);
@@ -198,7 +199,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('assets/.keep', [], exclusion)).toBe(false);
 		});
 
-		it('pattern/**/pattern：跨层级匹配', () => {
+		it('pattern/**/pattern matches across directory levels', () => {
 			const exclusion = makeRules(['foo/**/bar']);
 
 			expect(needIncludeFromGlobRules('foo/bar', [], exclusion)).toBe(false);
@@ -210,7 +211,7 @@ describe('needIncludeFromGlobRules', () => {
 		});
 	});
 
-	describe('综合示例规则', () => {
+	describe('Combined rule examples', () => {
 		const exclusion = makeRules([
 			'*.a',
 			'bin/',
@@ -220,7 +221,7 @@ describe('needIncludeFromGlobRules', () => {
 			'test[0-9].js',
 		]);
 
-		it('*.a：匹配所有目录下的 .a 文件', () => {
+		it('*.a matches .a files in any directory', () => {
 			expect(needIncludeFromGlobRules('lib.a', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('src/lib.a', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('src/lib.so', [], exclusion)).toBe(true);
@@ -228,7 +229,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('src/lib.a.bak', [], exclusion)).toBe(true);
 		});
 
-		it('bin/：忽略任意位置的 bin 目录', () => {
+		it('bin/ ignores bin directories at any depth', () => {
 			expect(needIncludeFromGlobRules('bin/tool', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('src/bin/tool', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('binfile', [], exclusion)).toBe(true);
@@ -236,7 +237,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('bin/../bin/tool', [], exclusion)).toBe(false);
 		});
 
-		it('/vendor/：仅忽略根目录的 vendor', () => {
+		it('/vendor/ ignores only the root vendor directory', () => {
 			expect(needIncludeFromGlobRules('vendor/lib.js', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('src/vendor/lib.js', [], exclusion)).toBe(true);
 			expect(needIncludeFromGlobRules('vendor', [], exclusion)).toBe(true);
@@ -244,14 +245,14 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('src/../vendor/lib.js', [], exclusion)).toBe(false);
 		});
 
-		it('logs/*.txt：仅匹配 logs 下一级 .txt', () => {
+		it('logs/*.txt matches only one level under logs', () => {
 			expect(needIncludeFromGlobRules('logs/app.txt', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('logs/history/2023.txt', [], exclusion)).toBe(true);
 			expect(needIncludeFromGlobRules('logs/app.txt/', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('logs/app.tx', [], exclusion)).toBe(true);
 		});
 
-		it('core/**/*.out：匹配 core 下任意深度 .out', () => {
+		it('core/**/*.out matches .out files at any depth under core', () => {
 			expect(needIncludeFromGlobRules('core/main.out', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('core/a/b/c/test.out', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('src/core/test.out', [], exclusion)).toBe(true);
@@ -259,7 +260,7 @@ describe('needIncludeFromGlobRules', () => {
 			expect(needIncludeFromGlobRules('core/test.output', [], exclusion)).toBe(true);
 		});
 
-		it('test[0-9].js：匹配 test0.js ~ test9.js', () => {
+		it('test[0-9].js matches test0.js through test9.js', () => {
 			expect(needIncludeFromGlobRules('test0.js', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('test9.js', [], exclusion)).toBe(false);
 			expect(needIncludeFromGlobRules('test10.js', [], exclusion)).toBe(true);

--- a/tests/webdav.test.ts
+++ b/tests/webdav.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { parseXML } from '~/utils/parse-xml';
+import { parseXML } from '~/composable/parse-xml';
 import requestUrl from '~/utils/request-url';
 
 vi.mock('~/utils/request-url', () => ({
 	default: vi.fn(),
 }));
-vi.mock('~/utils/parse-xml', () => ({
+vi.mock('~/composable/parse-xml', () => ({
 	parseXML: vi.fn(),
 }));
 vi.mock('~/utils/is-503-error', () => ({ is503Error: () => false }));


### PR DESCRIPTION
- Move API limiter to composable/api-limiter.ts and update imports
- Add composable/glob-match and migrate usage; adjust tests accordingly
- Introduce composable/i18n and refactor translation usage across code
- Introduce composable/unit-converter and reuse in input-converters
- Move XML parser to composable/parse-xml and update imports/tests
- Update path normalization and WebDAV utility imports to new locations
- Update readme labels: Polling and zh-Hans wording
- Align tests and mocks to new module paths and imports