### PR TITLE
fix(merge): handle undefined region.ok in diff3Merge result

### DIFF
--- a/src/sync/utils/merge.ts
+++ b/src/sync/utils/merge.ts
@@ -65,7 +65,7 @@ function diff3MergeStrings(
 	});
 
 	if (regions.some((region) => !region.ok)) return false;
-	return regions.flatMap((region) => region.ok).join('\n');
+	return regions.flatMap((region) => region.ok ?? []).join('\n');
 }
 
 export function resolveByIntelligentMerge(params: IntelligentMergeParams): IntelligentMergeResult {


### PR DESCRIPTION
## Summary

Fixes #147 — `undefined is not iterable` crash during merge conflict resolution.

## Root Cause

In `src/sync/utils/merge.ts`, the `diff3MergeStrings` function uses:
```typescript
return regions.flatMap((region) => region.ok).join('\n');
```

When `region.ok` is `undefined` (allowed by the `node-diff3` library types: `string[] | undefined`), `flatMap` throws:
`TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))`

## Fix

Use nullish coalescing to default `undefined` to an empty array:
```typescript
return regions.flatMap((region) => region.ok ?? []).join('\n');
```

This ensures undefined regions contribute no content, matching the intent of the prior `regions.some` guard check.

## Testing

```bash
npm test
```

Fixes #147