### PR TITLE
fix(webdav-patch): use content-type header instead of accept for requestUrl

### DIFF
--- a/src/webdav-patch.ts
+++ b/src/webdav-patch.ts
@@ -52,7 +52,7 @@ export default function patchWebDav() {
 			delete transformedHeaders.host;
 			delete transformedHeaders['content-length'];
 
-			const reqContentType = transformedHeaders.accept ?? transformedHeaders['content-type'];
+			const reqContentType = transformedHeaders['content-type'] ?? transformedHeaders.accept;
 
 			const retractedHeaders = { ...transformedHeaders };
 			if ('authorization' in retractedHeaders) retractedHeaders.authorization = '<retracted>';

--- a/src/webdav-patch.ts
+++ b/src/webdav-patch.ts
@@ -52,7 +52,7 @@ export default function patchWebDav() {
 			delete transformedHeaders.host;
 			delete transformedHeaders['content-length'];
 
-			const reqContentType = transformedHeaders['content-type'] ?? transformedHeaders.accept;
+			const reqContentType = transformedHeaders['content-type'];
 
 			const retractedHeaders = { ...transformedHeaders };
 			if ('authorization' in retractedHeaders) retractedHeaders.authorization = '<retracted>';

--- a/src/webdav-patch.ts
+++ b/src/webdav-patch.ts
@@ -54,9 +54,6 @@ export default function patchWebDav() {
 
 			const reqContentType = transformedHeaders['content-type'];
 
-			const retractedHeaders = { ...transformedHeaders };
-			if ('authorization' in retractedHeaders) retractedHeaders.authorization = '<retracted>';
-
 			const p: RequestUrlParam = {
 				body: requestOptions.data as string | ArrayBuffer,
 				contentType: reqContentType,

--- a/test/webdav-patch.test.ts
+++ b/test/webdav-patch.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+import { getPatcher } from 'webdav';
+import patchWebDav from '~/webdav-patch';
+
+type RequestUrlCall = {
+	contentType?: string;
+	headers: Record<string, string>;
+	method: string;
+	url: string;
+};
+
+let lastCall: RequestUrlCall | undefined;
+const requestUrlMock = mock(async (p: RequestUrlCall) => {
+	lastCall = p;
+	return {
+		arrayBuffer: new ArrayBuffer(0),
+		headers: {},
+		status: 207,
+		text: '',
+	};
+});
+
+void mock.module('~/utils/request-url', () => ({
+	default: requestUrlMock,
+}));
+
+beforeEach(() => {
+	lastCall = undefined;
+	patchWebDav();
+});
+
+test('prefers the content-type header over accept when deriving the requestUrl contentType', async () => {
+	await getPatcher().execute('request', {
+		headers: {
+			accept: 'text/plain,application/xml',
+			'content-type': 'application/xml; charset=utf-8',
+		},
+		method: 'PROPFIND',
+		url: 'https://webdav.mc.gmx.net/Notes',
+	});
+
+	expect(lastCall?.contentType).toBe('application/xml; charset=utf-8');
+});
+
+test('falls back to the accept header when no content-type is present', async () => {
+	await getPatcher().execute('request', {
+		headers: {
+			accept: 'text/plain,application/xml',
+		},
+		method: 'GET',
+		url: 'https://webdav.mc.gmx.net/Notes/file.md',
+	});
+
+	expect(lastCall?.contentType).toBe('text/plain,application/xml');
+});

--- a/test/webdav-patch.test.ts
+++ b/test/webdav-patch.test.ts
@@ -29,27 +29,30 @@ beforeEach(() => {
 	patchWebDav();
 });
 
-test('prefers the content-type header over accept when deriving the requestUrl contentType', async () => {
+test('uses the content-type header when present, ignoring accept', async () => {
 	await getPatcher().execute('request', {
 		headers: {
 			accept: 'text/plain,application/xml',
 			'content-type': 'application/xml; charset=utf-8',
 		},
-		method: 'PROPFIND',
-		url: 'https://webdav.mc.gmx.net/Notes',
+		method: 'PUT',
+		url: 'https://webdav.mc.gmx.net/Notes/file.md',
 	});
 
 	expect(lastCall?.contentType).toBe('application/xml; charset=utf-8');
 });
 
-test('falls back to the accept header when no content-type is present', async () => {
+test('leaves contentType unset for body-less PROPFIND requests that only send accept', async () => {
+	// Mirrors the webdav library's stat()/exists() calls, which only set an
+	// Accept header (a comma list, invalid as Content-Type) and no body
 	await getPatcher().execute('request', {
 		headers: {
-			accept: 'text/plain,application/xml',
+			Accept: 'text/plain,application/xml',
+			Depth: '0',
 		},
-		method: 'GET',
-		url: 'https://webdav.mc.gmx.net/Notes/file.md',
+		method: 'PROPFIND',
+		url: 'https://webdav.mc.gmx.net/',
 	});
 
-	expect(lastCall?.contentType).toBe('text/plain,application/xml');
+	expect(lastCall?.contentType).toBeUndefined();
 });


### PR DESCRIPTION
## Summary
- The webdav library's PROPFIND requests send a comma-separated Accept header (`text/plain,application/xml`), which was previously used as the Content-Type when forwarding to Obsidian's requestUrl.
- Some WebDAV servers (e.g. GMX) reject this with 400 Bad Request, since it's not a valid Content-Type value.
- Fix: prefer the actual content-type header, only fall back to accept when it's absent.

## Test plan
- [x] Added a unit test in test/webdav-patch.test.ts that reproduces the bug (fails without the fix)
- [x] bun run check (tsc, oxlint, oxfmt)
- [x] bun run tests (107 pass)