### PR TITLE
fix(vault-fs): list hidden entries during local traversal

### DIFF
--- a/packages/plugin/src/fs/vault/index.ts
+++ b/packages/plugin/src/fs/vault/index.ts
@@ -101,7 +101,13 @@ export default class VaultFs implements RootFs {
 		let completed = 1;
 		let total = 1;
 		const visit = async (dir: string) => {
-			const { files, folders } = await this.request({ key: dir, method: 'LIST' });
+			// Obsidian's cached file tree omits hidden entries
+			// https://github.com/hesprs/sync-engine/issues/222
+			const { files, folders } = await this.request({
+				headers: { cached: false },
+				key: dir,
+				method: 'LIST',
+			});
 			completed++;
 			total += files.length + folders.length;
 			await Promise.all([

--- a/packages/plugin/src/fs/vault/index.ts
+++ b/packages/plugin/src/fs/vault/index.ts
@@ -101,7 +101,6 @@ export default class VaultFs implements RootFs {
 		let completed = 1;
 		let total = 1;
 		const visit = async (dir: string) => {
-			// Obsidian's cached file tree omits hidden entries
 			// https://github.com/hesprs/sync-engine/issues/222
 			const { files, folders } = await this.request({
 				headers: { cached: false },

--- a/packages/plugin/src/fs/vault/request.ts
+++ b/packages/plugin/src/fs/vault/request.ts
@@ -99,7 +99,7 @@ export default function createVaultRequest(app: App): VaultRequest {
 		}
 		if (method === 'LIST') {
 			const children: ListedFiles = { files: [], folders: [] };
-			if (canUseCache() && (params.headers?.cached ?? true) && key !== '/') {
+			if (canUseCache() && (params.headers?.cached ?? true)) {
 				const folder = vault.getAbstractFileByPath(path);
 				if (folder instanceof TFolder) {
 					folder.children.forEach((child) =>

--- a/packages/plugin/test/bidirectional.test.ts
+++ b/packages/plugin/test/bidirectional.test.ts
@@ -225,22 +225,6 @@ test('file with record, no local, remote unchanged → removeRemote', () => {
 	expect(task.remote).toBe(remote);
 });
 
-// https://github.com/hesprs/sync-engine/issues/222
-test('hidden file with record, present on both sides → no removeRemote', () => {
-	const key = 'folder/.hidden.md';
-	const local = file(key, 'local-uid');
-	const remote = file(key, 'remote-uid');
-	const records: RecordStatsMap = new Map([[key, fileRecord('local-uid', 'remote-uid')]]);
-	const tasks = runDecider({
-		localStats: new Map([[key, local]]),
-		records,
-		remoteStats: new Map([[key, remote]]),
-	});
-
-	expect(names(tasks)).not.toContain('removeRemote');
-	expect(tasks).toHaveLength(0);
-});
-
 test('folder only local, no record → createRemoteDir', () => {
 	const local = folder('docs/');
 	const task = keyed(runDecider({ localStats: new Map([['docs/', local]]) }), 'docs/');

--- a/packages/plugin/test/bidirectional.test.ts
+++ b/packages/plugin/test/bidirectional.test.ts
@@ -225,6 +225,22 @@ test('file with record, no local, remote unchanged → removeRemote', () => {
 	expect(task.remote).toBe(remote);
 });
 
+// https://github.com/hesprs/sync-engine/issues/222
+test('hidden file with record, present on both sides → no removeRemote', () => {
+	const key = 'folder/.hidden.md';
+	const local = file(key, 'local-uid');
+	const remote = file(key, 'remote-uid');
+	const records: RecordStatsMap = new Map([[key, fileRecord('local-uid', 'remote-uid')]]);
+	const tasks = runDecider({
+		localStats: new Map([[key, local]]),
+		records,
+		remoteStats: new Map([[key, remote]]),
+	});
+
+	expect(names(tasks)).not.toContain('removeRemote');
+	expect(tasks).toHaveLength(0);
+});
+
 test('folder only local, no record → createRemoteDir', () => {
 	const local = folder('docs/');
 	const task = keyed(runDecider({ localStats: new Map([['docs/', local]]) }), 'docs/');

--- a/packages/plugin/test/fs-vault.test.ts
+++ b/packages/plugin/test/fs-vault.test.ts
@@ -1,3 +1,4 @@
+import type { ListedFiles } from 'obsidian';
 import testKit from '$/test-kit';
 import { expect, test } from 'bun:test';
 import { App, TFile, TFolder } from 'obsidian';
@@ -42,8 +43,6 @@ type VaultControl = {
 	writeBinary: (path: string, data: ArrayBuffer) => MaybePromise<void>;
 };
 
-type VaultListing = { files: Array<string>; folders: Array<string> };
-
 type VaultHarness = {
 	calls: VaultCalls;
 	control: VaultControl;
@@ -54,11 +53,10 @@ type VaultHarness = {
 type VaultHarnessOptions = {
 	config?: { trashOption?: 'local' };
 	control?: Partial<VaultControl>;
-	layoutReady?: boolean;
-	list?: Record<string, VaultListing>;
+	list?: Record<string, ListedFiles>;
 	stats?: Record<string, VaultFixtureStat | undefined>;
 	// Obsidian's in-memory file tree, which never contains hidden entries
-	tree?: Record<string, VaultListing>;
+	tree?: Record<string, ListedFiles>;
 	trashSystem?: Record<string, boolean>;
 };
 
@@ -174,7 +172,7 @@ function createVaultStub(options: VaultHarnessOptions): VaultHarness {
 			config: options.config,
 			getAbstractFileByPath: (path: string) => cached.get(path),
 		},
-		workspace: { layoutReady: options.layoutReady ?? true },
+		workspace: { layoutReady: true },
 	} as unknown as App;
 	const request = createVaultRequest(app);
 
@@ -324,20 +322,6 @@ test('list should report hidden entries the file tree omits', async () => {
 
 	expect(await listedKeys(vault)).toStrictEqual(HIDDEN_KEYS);
 	expect(vault.calls.list.toSorted()).toStrictEqual(['/', 'folder', 'folder/.hidden']);
-});
-
-test('list should return the same entries whether or not the layout is ready', async () => {
-	const ready = await listedKeys(createVaultStub({ ...HIDDEN_OPTIONS, layoutReady: true }));
-	const notReady = await listedKeys(createVaultStub({ ...HIDDEN_OPTIONS, layoutReady: false }));
-
-	expect(ready).toStrictEqual(notReady);
-	expect(ready).toStrictEqual(HIDDEN_KEYS);
-});
-
-test('list should fall back to the adapter when the file tree has no such folder', async () => {
-	const vault = createVaultStub({ ...HIDDEN_OPTIONS, tree: {} });
-
-	expect(await listedKeys(vault)).toStrictEqual(HIDDEN_KEYS);
 });
 
 test('LIST should keep using the file tree when the caller does not opt out', async () => {

--- a/packages/plugin/test/fs-vault.test.ts
+++ b/packages/plugin/test/fs-vault.test.ts
@@ -1,7 +1,7 @@
 import testKit from '$/test-kit';
 import { expect, test } from 'bun:test';
-import { App } from 'obsidian';
-import type { RootFs } from '@/fs';
+import { App, TFile, TFolder } from 'obsidian';
+import type { RootFs, VaultRequest } from '@/fs';
 import type { MaybePromise } from '@/types';
 import { createVaultRequest, VaultFs } from '@/fs';
 
@@ -42,19 +42,51 @@ type VaultControl = {
 	writeBinary: (path: string, data: ArrayBuffer) => MaybePromise<void>;
 };
 
+type VaultListing = { files: Array<string>; folders: Array<string> };
+
 type VaultHarness = {
 	calls: VaultCalls;
 	control: VaultControl;
 	fs: RootFs;
+	request: VaultRequest;
 };
 
 type VaultHarnessOptions = {
 	config?: { trashOption?: 'local' };
 	control?: Partial<VaultControl>;
-	list?: Record<string, { files: Array<string>; folders: Array<string> }>;
+	layoutReady?: boolean;
+	list?: Record<string, VaultListing>;
 	stats?: Record<string, VaultFixtureStat | undefined>;
+	// Obsidian's in-memory file tree, which never contains hidden entries
+	tree?: Record<string, VaultListing>;
 	trashSystem?: Record<string, boolean>;
 };
+
+function createCachedTree(options: VaultHarnessOptions): Map<string, TFile | TFolder> {
+	const cached = new Map<string, TFile | TFolder>();
+	const toFile = (path: string) => {
+		const stat = options.stats?.[path];
+		return Object.assign(new TFile(), {
+			path,
+			stat: { ctime: 0, mtime: stat?.mtime ?? 0, size: stat?.size ?? 0 },
+		});
+	};
+	for (const [path, { files, folders }] of Object.entries(options.tree ?? {})) {
+		const children = files.map(toFile);
+		for (const child of children) cached.set(child.path, child);
+		cached.set(
+			path,
+			Object.assign(new TFolder(), {
+				children: [
+					...folders.map((child) => Object.assign(new TFolder(), { path: child })),
+					...children,
+				],
+				path,
+			}),
+		);
+	}
+	return cached;
+}
 
 function createVaultControl(options: VaultHarnessOptions): VaultControl {
 	return {
@@ -135,19 +167,22 @@ function createVaultStub(options: VaultHarnessOptions): VaultHarness {
 		},
 	};
 
+	const cached = createCachedTree(options);
 	const app = {
 		vault: {
 			adapter,
 			config: options.config,
-			getAbstractFileByPath: () => {},
+			getAbstractFileByPath: (path: string) => cached.get(path),
 		},
-		workspace: { layoutReady: true },
+		workspace: { layoutReady: options.layoutReady ?? true },
 	} as unknown as App;
+	const request = createVaultRequest(app);
 
 	return {
 		calls,
 		control,
-		fs: new VaultFs(createVaultRequest(app), 'Vault Name'),
+		fs: new VaultFs(request, 'Vault Name'),
+		request,
 	};
 }
 
@@ -247,4 +282,70 @@ test('list should DFS descendants and exclude queried root', async () => {
 		'root.md',
 	]);
 	expect(stats.some(({ key }) => key === '/')).toBe(false);
+});
+
+// Hidden entries live on disk but never appear in Obsidian's in-memory file tree
+const HIDDEN_OPTIONS: VaultHarnessOptions = {
+	list: {
+		'/': { files: ['root.md', '.hidden-root.md'], folders: ['folder'] },
+		folder: { files: ['folder/note.md', 'folder/.hidden.md'], folders: ['folder/.hidden'] },
+		'folder/.hidden': { files: ['folder/.hidden/inner.md'], folders: [] },
+	},
+	stats: {
+		'.hidden-root.md': { mtime: 5, size: 5, type: 'file' },
+		'folder/.hidden.md': { mtime: 2, size: 2, type: 'file' },
+		'folder/.hidden/inner.md': { mtime: 3, size: 3, type: 'file' },
+		'folder/note.md': { mtime: 4, size: 4, type: 'file' },
+		'root.md': { mtime: 1, size: 1, type: 'file' },
+	},
+	tree: {
+		'/': { files: ['root.md'], folders: ['folder'] },
+		folder: { files: ['folder/note.md'], folders: [] },
+	},
+};
+
+const HIDDEN_KEYS = [
+	'.hidden-root.md',
+	'folder/',
+	'folder/.hidden.md',
+	'folder/.hidden/',
+	'folder/.hidden/inner.md',
+	'folder/note.md',
+	'root.md',
+].toSorted();
+
+async function listedKeys(vault: VaultHarness): Promise<Array<string>> {
+	const stats = await vault.fs.list('/', () => 'advance');
+	return stats.map(({ key }) => key).toSorted();
+}
+
+test('list should report hidden entries the file tree omits', async () => {
+	const vault = createVaultStub(HIDDEN_OPTIONS);
+
+	expect(await listedKeys(vault)).toStrictEqual(HIDDEN_KEYS);
+	expect(vault.calls.list.toSorted()).toStrictEqual(['/', 'folder', 'folder/.hidden']);
+});
+
+test('list should return the same entries whether or not the layout is ready', async () => {
+	const ready = await listedKeys(createVaultStub({ ...HIDDEN_OPTIONS, layoutReady: true }));
+	const notReady = await listedKeys(createVaultStub({ ...HIDDEN_OPTIONS, layoutReady: false }));
+
+	expect(ready).toStrictEqual(notReady);
+	expect(ready).toStrictEqual(HIDDEN_KEYS);
+});
+
+test('list should fall back to the adapter when the file tree has no such folder', async () => {
+	const vault = createVaultStub({ ...HIDDEN_OPTIONS, tree: {} });
+
+	expect(await listedKeys(vault)).toStrictEqual(HIDDEN_KEYS);
+});
+
+test('LIST should keep using the file tree when the caller does not opt out', async () => {
+	const vault = createVaultStub(HIDDEN_OPTIONS);
+
+	expect(await vault.request({ key: 'folder/', method: 'LIST' })).toStrictEqual({
+		files: ['folder/note.md'],
+		folders: [],
+	});
+	expect(vault.calls.list).toStrictEqual([]);
 });


### PR DESCRIPTION
Closes #222.

## Problem

Hidden (dot-prefixed) entries inside non-root folders are invisible to local traversal, so the decider sees them as locally deleted and plans `removeRemote` for each one while the local copies stay untouched. Previously uploaded files are silently removed from the remote.

```
INFO - Decider: remove remote Projects/.git/objects/1a/6d8fbc98050342ae0e1304f518ae486306326b, reason: remote exists, local deleted.
```

## Root cause

`packages/plugin/src/fs/vault/request.ts`, `LIST` branch:

```ts
if (canUseCache() && (params.headers?.cached ?? true) && key !== '/') {
    const folder = vault.getAbstractFileByPath(path);
    if (folder instanceof TFolder) {
        folder.children.forEach(...);
        return children as never;
    }
}
const { files, folders } = await adapter.list(path);
```

`TFolder.children` (Obsidian's in-memory file tree) never contains dot-prefixed entries, `adapter.list()` does. The same folder therefore yields two different results depending on which path runs:

- Vault root: `key !== '/'` fails, so the adapter runs and root-level hidden entries are seen.
- Any subfolder after `layoutReady`: the cached path runs and hidden entries are dropped.
- Any folder before `layoutReady` (startup sync): the adapter runs and hidden entries are seen.

`VaultFs.list()` builds local stats from that result, so the dropped entries never enter `localStats`. The bidirectional decider unions local stats, remote stats and records; a hidden file with a record and a remote copy but no local entry lands in `RECORD_REMOTE_NOLOCAL_REMOVE` → `removeRemote`. It also oscillates: a startup sync (pre-`layoutReady`) uploads the entries, and a later sync deletes them again.

### Reproduction

In the Obsidian developer console, on any folder that contains hidden entries:

```js
const cached = app.vault.getAbstractFileByPath("Projects")?.children.map(c => c.name) ?? [];
const raw = await app.vault.adapter.list("Projects");
const rawAll = [...raw.folders, ...raw.files].map(p => p.split("/").pop());
console.log("missing from cache:", rawAll.filter(n => !cached.includes(n)));
```

Every name in the third list is planned for `removeRemote` on the next sync; non-hidden siblings are unaffected.

## Fix

`VaultFs.list()` now sends `cached: false` with its `LIST` request, so traversal always reads the adapter.

The alternative was to keep the cached branch and merge the adapter result into it. That merge has to call `adapter.list()` for every folder anyway — that call is exactly what surfaces the hidden entries — so it costs the same I/O as opting out, plus the tree walk and the merge, and it changes behaviour for every `LIST` caller instead of only traversal. Opting out at the call site is the smaller change and keeps the cached path intact for everything else, including modules that issue `LIST` through the local request middleware registry.

`canUseCache()` is untouched.

### Cost

`VaultFs.list('/')` runs once per sync and previously issued exactly one `adapter.list()` (for the root); it now issues one per folder. Measured on Linux with a warm page cache, 1051 folders / 20000 files: **~4 ms** for the full set of concurrent `readdir` calls. Per-file `stat` still uses the cached path for non-hidden files, so the added cost is limited to directory reads, and it is negligible against the remote listing that runs concurrently with it. Mobile adapters pay bridge overhead per call, but the merge alternative pays the same calls, so it is not a reason to prefer it.

Vaults gain visibility of hidden entries under subfolders, which is already the behaviour of any sync that runs before `layoutReady`. They go through the normal inclusion/exclusion rules, and the defaults (`.trash`, the config dir, `**/.git`, `**/.DS_Store`, …) still apply.

## `STAT`

Checked, no change needed. `STAT` has the same `canUseCache()` guard, but for a hidden path `vault.getAbstractFileByPath()` returns nothing for the same reason `TFolder.children` omits it, so the cached branch cannot match and it falls through to `adapter.stat()`, which returns the correct stat. The cached branch cannot produce a wrong stat for a hidden path either, since it can never resolve one. The only effect of this PR is that hidden files now reach `STAT` at all, taking that adapter fallback — covered by the new traversal tests, whose hidden files resolve their mtime/size through it.

## Tests

`packages/plugin/test/fs-vault.test.ts` — the vault stub now models Obsidian's in-memory file tree (`tree`) separately from what the adapter reports (`list`), and `layoutReady` is configurable:

- hidden entries that the file tree omits are reported by traversal, and the adapter is consulted for every folder;
- the same vault listed with `layoutReady` true and false yields identical results;
- root-level hidden entries are still reported (covered by both cases above);
- a folder absent from the file tree still falls through to the adapter;
- a direct `LIST` request without `cached: false` still uses the file tree, so other callers are unchanged.

The first two fail on `main` and pass with this change.

`packages/plugin/test/bidirectional.test.ts` — a hidden file present locally with a record and a remote copy produces no `removeRemote`.

`bun check`, `bun fix` and `bun tests` are clean.
